### PR TITLE
arduino-cli: correct size and add checksum

### DIFF
--- a/package_m328pb_index.json
+++ b/package_m328pb_index.json
@@ -16,7 +16,8 @@
           "help": {"online": "https://github.com/SensorDots/PortMuxRBoard"},
           "url": "https://github.com/SensorDots/PortMuxRBoard/raw/master/m328pb-1.1.3.zip",
           "archiveFileName": "m328pb-1.1.3.zip",
-          "size": "84531",
+          "size": "84287",
+          "checksum": "SHA-256:e08744f2816c1b4650605e7f45b002e6c377bf859a3bc77fc68d1ab6689268bc",
           "boards": [
             {"name": "Port MuxR"}
           ]


### PR DESCRIPTION
arduino-cli has more strict requirements than the "IDE". These entries are needed to be able to install the platform.